### PR TITLE
issue #11 - implement the CF resource

### DIFF
--- a/src/main/kotlin/io/poyarzun/concoursedsl/resources/CfResource.kt
+++ b/src/main/kotlin/io/poyarzun/concoursedsl/resources/CfResource.kt
@@ -1,0 +1,56 @@
+package io.poyarzun.concoursedsl.resources
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategy
+import com.fasterxml.jackson.databind.annotation.JsonNaming
+import io.poyarzun.concoursedsl.domain.Pipeline
+import io.poyarzun.concoursedsl.domain.Resource
+import io.poyarzun.concoursedsl.domain.Step
+import io.poyarzun.concoursedsl.dsl.ConfigBlock
+import io.poyarzun.concoursedsl.dsl.StepBuilder
+import io.poyarzun.concoursedsl.dsl.baseResource
+
+// https://github.com/concourse/cf-resource
+object Cf {
+    @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy::class)
+    data class SourceParams(
+            val api: String,
+            val organization: String,
+            val space: String,
+            var username: String? = null,
+            var password: String? = null,
+            var clientId: String? = null,
+            var clientSecret: String? = null,
+            var skipCertCheck: Boolean? = null,
+            var verbose: Boolean? = null
+    )
+
+    class GetParams
+
+    @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy::class)
+    data class PutParams(
+            val manifest: String,
+            var path: String? = null,
+            var currentAppName: String? = null,
+            var environmentVariables: Map<String, String>? = null,
+            var vars: Map<String, String>? = null,
+            var varsFiles: List<String>? = null,
+            var dockerUserName: String? = null,
+            var dockerPassword: String? = null,
+            var showAppLog: Boolean? = null,
+            var noStart: Boolean? = null
+    )
+
+}
+
+fun Pipeline.cfResource(name: String,
+                        api: String,
+                        organization: String,
+                        space: String,
+                        configBlock: ConfigBlock<Resource<Cf.SourceParams>>) =
+        this.baseResource(name, "cf", Cf.SourceParams(api, organization, space), configBlock)
+
+fun StepBuilder.get(resource: Resource<Cf.SourceParams>, configBlock: ConfigBlock<Step.GetStep<Cf.GetParams>>) =
+        this.baseGet(resource.name, Cf.GetParams(), configBlock)
+
+fun StepBuilder.put(resource: Resource<Cf.SourceParams>, manifest: String, configBlock: ConfigBlock<Step.PutStep<Cf.GetParams, Cf.PutParams>>) =
+        this.basePut(resource.name, Cf.PutParams(manifest), Cf.GetParams(), configBlock)

--- a/src/test/kotlin/io/poyarzun/concoursedsl/dsl/resources/CfResourceTest.kt
+++ b/src/test/kotlin/io/poyarzun/concoursedsl/dsl/resources/CfResourceTest.kt
@@ -1,0 +1,171 @@
+package io.poyarzun.concoursedsl.dsl.resources
+import io.poyarzun.concoursedsl.domain.Resource
+import io.poyarzun.concoursedsl.dsl.*
+import io.poyarzun.concoursedsl.resources.Cf
+import io.poyarzun.concoursedsl.resources.cfResource
+import io.poyarzun.concoursedsl.resources.put
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class CfResourceTest {
+
+    @Test
+    fun completeYaml() {
+
+        val actualYaml = generateYML(pipeline {
+            val resource: Resource<Cf.SourceParams> = cfResource(
+                    "resource-deploy-web-app",
+                    "https://api.run.pivotal.io",
+                    "ORG",
+                    "SPACE") {
+                source {
+                    username = "EMAIL"
+                    password = "PASSWORD"
+                    skipCertCheck = false
+                    clientId = "client-id"
+                    clientSecret = "1Ur7Nyq4CtROxW9q4MUr"
+                    verbose = true
+
+                }
+            }
+
+            job("job-deploy-app") {
+                plan {
+                    put(resource, "build-output/manifest.yml") {
+                        params {
+                            path="/build/lib/my-springboot-app.jar"
+                            currentAppName = "turquoise-app"
+                            vars = mapOf(
+                                    "alpha" to "apple",
+                                    "beta" to "banana"
+                            )
+                            varsFiles = listOf("mu.properties", "nu.properties")
+                            dockerPassword = "gibberish"
+                            dockerUserName = "simon"
+                            showAppLog = true
+                            noStart = false
+                            environmentVariables =
+                                    mapOf(
+                                            "key" to "value",
+                                            "key2" to "value2")
+                        }
+                    }
+                }
+            }
+
+        })
+
+        val expectedYaml = """
+            ---
+            jobs:
+            - name: "job-deploy-app"
+              plan:
+              - put: "resource-deploy-web-app"
+                params:
+                  manifest: "build-output/manifest.yml"
+                  path: "/build/lib/my-springboot-app.jar"
+                  current_app_name: "turquoise-app"
+                  environment_variables:
+                    key: "value"
+                    key2: "value2"
+                  vars:
+                    alpha: "apple"
+                    beta: "banana"
+                  vars_files:
+                  - "mu.properties"
+                  - "nu.properties"
+                  docker_user_name: "simon"
+                  docker_password: "gibberish"
+                  show_app_log: true
+                  no_start: false
+                get_params: {}
+            groups: []
+            resources:
+            - name: "resource-deploy-web-app"
+              type: "cf"
+              source:
+                api: "https://api.run.pivotal.io"
+                organization: "ORG"
+                space: "SPACE"
+                username: "EMAIL"
+                password: "PASSWORD"
+                client_id: "client-id"
+                client_secret: "1Ur7Nyq4CtROxW9q4MUr"
+                skip_cert_check: false
+                verbose: true
+            resource_types: []
+
+            """.trimIndent()
+
+        assertEquals(expectedYaml, actualYaml)
+
+    }
+
+    @Test
+    fun testDocumentYaml() {
+
+        // recreates the sample from this page
+        // https://github.com/concourse/cf-resource
+
+        val actualYaml = generateYML(pipeline {
+            val resource: Resource<Cf.SourceParams> = cfResource(
+                    "resource-deploy-web-app",
+                    "https://api.run.pivotal.io",
+                    "ORG",
+                    "SPACE") {
+                source {
+                    username = "EMAIL"
+                    password = "PASSWORD"
+                    skipCertCheck = false
+                }
+            }
+
+            job("job-deploy-app") {
+                plan {
+                    put(resource, "build-output/manifest.yml") {
+                        params {
+                            environmentVariables =
+                                    mapOf(
+                                            "key" to "value",
+                                            "key2" to "value2")
+                        }
+                    }
+                }
+            }
+
+        })
+
+        val expectedYaml = """
+            ---
+            jobs:
+            - name: "job-deploy-app"
+              plan:
+              - put: "resource-deploy-web-app"
+                params:
+                  manifest: "build-output/manifest.yml"
+                  environment_variables:
+                    key: "value"
+                    key2: "value2"
+                get_params: {}
+            groups: []
+            resources:
+            - name: "resource-deploy-web-app"
+              type: "cf"
+              source:
+                api: "https://api.run.pivotal.io"
+                organization: "ORG"
+                space: "SPACE"
+                username: "EMAIL"
+                password: "PASSWORD"
+                skip_cert_check: false
+            resource_types: []
+
+            """
+                .trimIndent()
+
+
+        assertEquals(expectedYaml, actualYaml)
+
+    }
+
+}


### PR DESCRIPTION
Implemented the CF resource as a typesafe extension to the DSL

Used the fly validate-pipeline command to verify that the expected YAML in the unit tests are valid pipelines.    The files used to test are attached.

The only thing I did differently from the Git resource was to use "List" and "Map" instead of the Mutable* equivalents.  I didn't see a reason for the collections to be mutable, but if that was deliberate, I can revise my code.

[test-2.txt](https://github.com/Logiraptor/concourse-dsl/files/3119518/test-2.txt)
[test.txt](https://github.com/Logiraptor/concourse-dsl/files/3119519/test.txt)