### PR TITLE
issue 14 - restructure test packages for Resource implementations

### DIFF
--- a/src/test/kotlin/io/poyarzun/concoursedsl/resources/CfResourceTest.kt
+++ b/src/test/kotlin/io/poyarzun/concoursedsl/resources/CfResourceTest.kt
@@ -1,9 +1,6 @@
-package io.poyarzun.concoursedsl.dsl.resources
+package io.poyarzun.concoursedsl.resources
 import io.poyarzun.concoursedsl.domain.Resource
 import io.poyarzun.concoursedsl.dsl.*
-import io.poyarzun.concoursedsl.resources.Cf
-import io.poyarzun.concoursedsl.resources.cfResource
-import io.poyarzun.concoursedsl.resources.put
 import org.junit.Test
 import kotlin.test.assertEquals
 

--- a/src/test/kotlin/io/poyarzun/concoursedsl/resources/GitResourceTest.kt
+++ b/src/test/kotlin/io/poyarzun/concoursedsl/resources/GitResourceTest.kt
@@ -1,7 +1,6 @@
-package io.poyarzun.concoursedsl.dsl.resources
+package io.poyarzun.concoursedsl.resources
 
 import io.poyarzun.concoursedsl.dsl.*
-import io.poyarzun.concoursedsl.resources.*
 import org.junit.Test
 import kotlin.test.assertEquals
 

--- a/src/test/kotlin/io/poyarzun/concoursedsl/resources/HgResourceTest.kt
+++ b/src/test/kotlin/io/poyarzun/concoursedsl/resources/HgResourceTest.kt
@@ -1,9 +1,8 @@
-package io.poyarzun.concoursedsl.dsl.resources
+package io.poyarzun.concoursedsl.resources
 
 import io.poyarzun.concoursedsl.dsl.generateYML
 import io.poyarzun.concoursedsl.dsl.*
 import io.poyarzun.concoursedsl.dsl.pipeline
-import io.poyarzun.concoursedsl.resources.*
 import org.junit.Test
 import kotlin.test.assertEquals
 

--- a/src/test/kotlin/io/poyarzun/concoursedsl/resources/TimeResourceTest.kt
+++ b/src/test/kotlin/io/poyarzun/concoursedsl/resources/TimeResourceTest.kt
@@ -1,9 +1,8 @@
-package io.poyarzun.concoursedsl.dsl.resources
+package io.poyarzun.concoursedsl.resources
 
 import io.poyarzun.concoursedsl.dsl.generateYML
 import io.poyarzun.concoursedsl.dsl.*
 import io.poyarzun.concoursedsl.dsl.pipeline
-import io.poyarzun.concoursedsl.resources.*
 import org.junit.Test
 import kotlin.test.assertEquals
 


### PR DESCRIPTION
Tests for Resource implementations are moved to `io.poyarzun.concoursedsl.resources` to align the associated source code.